### PR TITLE
cmake refactoring part 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,22 +51,34 @@ include_directories( "libs/q/include" )
 add_subdirectory( "libs/q" )
 
 if (${PROJECT_NAME}_BUILD_TESTS)
-  enable_testing()
-  include_directories( "3rdparty/gmock-1.7.0/gtest/include/" )
-  include_directories( "3rdparty/gmock-1.7.0/include/" )
-  include_directories( "libs/q-test/include" )
-  add_subdirectory( "libs/q-test" )
-  add_subdirectory( "3rdparty/gmock-1.7.0" )
-  add_subdirectory( "tests" )
+    enable_testing()
+    include_directories( "3rdparty/gmock-1.7.0/gtest/include/" )
+    include_directories( "3rdparty/gmock-1.7.0/include/" )
+    include_directories( "libs/q-test/include" )
+    add_subdirectory( "libs/q-test" )
+    add_subdirectory( "3rdparty/gmock-1.7.0" )
+    add_subdirectory( "tests" )
 endif(${PROJECT_NAME}_BUILD_TESTS)
 
 
 # TODO does not exits, can be removed ?
-include_directories( "3rdparty/dist/include/" )
+# include_directories( "3rdparty/dist/include/" )
 
-# TODO for distribution, these are not needed, make optional
-add_subdirectory( "progs/playground" )
-add_subdirectory( "progs/benchmark" )
+# make apps optional
+if ( DEFINED ${PROJECT_NAME}_BUILD_APPS )
+	option(
+		${PROJECT_NAME}_BUILD_APPS
+		"build sample and playgournd apps"
+		${PROJECT_NAME}_BUILD_APPS )
+else ( )
+	option( ${PROJECT_NAME}_BUILD_APPS "build tests" ON )
+endif ( )
+
+
+if (${PROJECT_NAME}_BUILD_APPS)
+    add_subdirectory( "progs/playground" )
+    add_subdirectory( "progs/benchmark" )
+endif ( )
 
 configure_file(
 	"${CMAKE_CURRENT_SOURCE_DIR}/cmake/libq.pc.cmake.cfg"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,25 +50,23 @@ endif ( )
 include_directories( "libs/q/include" )
 add_subdirectory( "libs/q" )
 
-if ( ${PROJECT_NAME}_BUILD_TESTS )
-	include_directories( "3rdparty/gmock-1.7.0/gtest/include/" )
-	include_directories( "3rdparty/gmock-1.7.0/include/" )
-	include_directories( "libs/q-test/include" )
-	add_subdirectory( "libs/q-test" )
-endif ( )
+if (${PROJECT_NAME}_BUILD_TESTS)
+  enable_testing()
+  include_directories( "3rdparty/gmock-1.7.0/gtest/include/" )
+  include_directories( "3rdparty/gmock-1.7.0/include/" )
+  include_directories( "libs/q-test/include" )
+  add_subdirectory( "libs/q-test" )
+  add_subdirectory( "3rdparty/gmock-1.7.0" )
+  add_subdirectory( "tests" )
+endif(${PROJECT_NAME}_BUILD_TESTS)
+
 
 # TODO does not exits, can be removed ?
 include_directories( "3rdparty/dist/include/" )
 
+# TODO for distribution, these are not needed, make optional
 add_subdirectory( "progs/playground" )
 add_subdirectory( "progs/benchmark" )
-
-if ( ${PROJECT_NAME}_BUILD_TESTS )
-	# TODO if mocking is needed, switch to Trompeloeil
-	add_subdirectory( "3rdparty/gmock-1.7.0" )
-	add_subdirectory( "tests/qtest" )
-	add_subdirectory( "tests/q" )
-endif ( )
 
 configure_file(
 	"${CMAKE_CURRENT_SOURCE_DIR}/cmake/libq.pc.cmake.cfg"

--- a/cmake/compilersetup.cmake
+++ b/cmake/compilersetup.cmake
@@ -24,12 +24,14 @@ if ( CMAKE_CXX_COMPILER_ID MATCHES "GNU" )
 
 	if ( NOT CMAKE_EXE_LINKER_FLAGS )
 		set( CMAKE_EXE_LINKER_FLAGS "-ldl -lpthread" )
-		# The above seems not to work, while manually adding them works:
-		set( GENERIC_LIB_DEPS dl pthread )
 		set( CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} CACHE STRING
 			"Flags used by the linker during the creation of modules."
 			FORCE )
 	endif ( )
+
+	# some need them always in at the end, so add them always
+	set( GENERIC_LIB_DEPS dl pthread )
+
 
 elseif ( CMAKE_CXX_COMPILER_ID MATCHES "Clang" )
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,8 @@
+
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/tests)
+
+add_subdirectory( "qtest" )
+add_subdirectory( "q" )
+
+

--- a/tests/q/CMakeLists.txt
+++ b/tests/q/CMakeLists.txt
@@ -2,9 +2,9 @@
 find_source_tree( LIBQ_TEST_HEADERS "Header Files" src "*.hpp" )
 find_source_tree( LIBQ_TEST_SOURCES "Source Files" src "*.cpp" )
 
-include_directories( "3rdparty/gmock-1.7.0/include" )
 
 add_executable( q-unit-tests ${LIBQ_TEST_HEADERS} ${LIBQ_TEST_SOURCES} )
 
-target_link_libraries( q-unit-tests q-test q gmock_main ${CXXLIB} )
+target_link_libraries( q-unit-tests q-test q gmock_main ${CXXLIB} ${GENERIC_LIB_DEPS})
 
+add_test( NAME q-unit-tests COMMAND  q-unit-tests )

--- a/tests/qtest/CMakeLists.txt
+++ b/tests/qtest/CMakeLists.txt
@@ -2,8 +2,9 @@
 find_source_tree( LIBQ_TEST_HEADERS "Header Files" src "*.hpp" )
 find_source_tree( LIBQ_TEST_SOURCES "Source Files" src "*.cpp" )
 
-include_directories( "3rdparty/gmock-1.7.0/include" )
 
 add_executable( qtest-unit-tests ${LIBQ_TEST_HEADERS} ${LIBQ_TEST_SOURCES} )
 
-target_link_libraries( qtest-unit-tests q-test q gmock_main ${CXXLIB} )
+target_link_libraries( qtest-unit-tests q-test q gmock_main ${CXXLIB} ${GENERIC_LIB_DEPS} )
+
+add_test( NAME qtest-unit-tests COMMAND  qtest-unit-tests )


### PR DESCRIPTION
* revert revert == reactivate generic flags, but ensure they are always set, also after re-run of cmake in an existing build folder
* make building apps optional, 
* activated ctest if test are build

build only tests  and run both test binaries works now like this
```
cmake -DCMAKE_BUILD_TYPE=Debug -Dq_BUILD_APPS=OFF ../
make
make test
```

