### PR TITLE
Fix compilation on FreeBSD systems

### DIFF
--- a/libs/q/src/detail/stacktrace_default.cpp
+++ b/libs/q/src/detail/stacktrace_default.cpp
@@ -34,7 +34,7 @@ namespace detail {
 stacktrace::frame parse_stack_frame( const char* data )
 noexcept
 {
-	return stacktrace::frame{ 0, "", 0, data, "" };
+	return stacktrace::frame{ 0, "", 0, 0, data, "" };
 }
 
 #endif


### PR DESCRIPTION
FreeBSD does not allow getting thread names (but allows setting it). Uses a thread_local workaround similar to the one on the Windows platform.

Also, there was a parameter miss match on stacktrace_default.cpp which prevented compilation.