### PR TITLE
Fix compilation on Android

### DIFF
--- a/libs/q/include/q/pp.hpp
+++ b/libs/q/include/q/pp.hpp
@@ -38,6 +38,9 @@
 #elif defined( __linux__ )
 #	define LIBQ_ON_LINUX
 #	define LIBQ_ON_POSIX
+#   if defined( __ANDROID__ ) || defined(ANDROID)
+#		define LIBQ_ON_ANDROID
+#   endif
 #elif defined( __FreeBSD__ )
 #	define LIBQ_ON_FREEBSD
 #	define LIBQ_ON_BSD

--- a/libs/q/src/detail/exec.hpp
+++ b/libs/q/src/detail/exec.hpp
@@ -55,7 +55,9 @@ std::string exec_read_all( const std::string& prog, std::size_t bytes = 4096 )
 			::close( stdout_pipe[ 0 ] );
 			::dup2( stdout_pipe[ 1 ], 1 );
 
+#if !defined(LIBQ_ON_ANDROID)
 			::setenv( "LANG", "C", 1 );
+#endif
 
 			char* const args[ 2 ] = {
 				::strdup( prog.c_str( ) ),

--- a/libs/q/src/detail/numeric.hpp
+++ b/libs/q/src/detail/numeric.hpp
@@ -96,6 +96,8 @@ msb( type&& _num )
 #endif
 }
 
+#if !defined(LIBQ_ON_ANDROID)
+
 template< typename type, std::size_t size = sizeof( type ) >
 typename std::enable_if< size <= sizeof( long long int ), std::size_t >::type
 lsb( type&& _num )
@@ -104,6 +106,8 @@ lsb( type&& _num )
 
 	return static_cast< std::size_t >( ffsll( num ) );
 }
+
+#endif
 
 } // namespace detail
 

--- a/libs/q/src/detail/stacktrace_default.cpp
+++ b/libs/q/src/detail/stacktrace_default.cpp
@@ -19,7 +19,7 @@
 
 #include "stacktrace.hpp"
 
-#ifndef LIBQ_ON_WINDOWS
+#if !defined(LIBQ_ON_WINDOWS) && !defined(LIBQ_ON_ANDROID)
 #	include <execinfo.h>
 #endif
 
@@ -39,7 +39,7 @@ noexcept
 
 #endif
 
-#ifndef LIBQ_ON_WINDOWS
+#if !defined(LIBQ_ON_WINDOWS) && !defined(LIBQ_ON_ANDROID)
 
 stacktrace default_stacktrace( ) noexcept
 {
@@ -64,6 +64,12 @@ stacktrace default_stacktrace( ) noexcept
 	::free( raw_frames );
 
 	return stacktrace( std::move( frames ) );
+}
+
+#elif defined(LIBQ_ON_ANDROID)
+stacktrace default_stacktrace( ) noexcept
+{
+    return stacktrace(std::vector< stacktrace::frame >());
 }
 
 #endif

--- a/libs/q/src/stacktrace.cpp
+++ b/libs/q/src/stacktrace.cpp
@@ -24,6 +24,7 @@
 #include <atomic>
 #include <sstream>
 #include <cstring>
+#include <string>
 
 namespace q {
 

--- a/libs/q/src/thread.cpp
+++ b/libs/q/src/thread.cpp
@@ -24,7 +24,7 @@
 	static thread_local std::string threadname_;
 #elif defined( LIBQ_ON_OSX )
 #elif defined( LIBQ_ON_POSIX )
-#ifdef LIBQ_ON_BSD
+#if defined(LIBQ_ON_BSD) || defined(LIBQ_ON_ANDROID)
 	static thread_local std::string threadname_;
 #endif
 #	include <pthread.h>
@@ -81,7 +81,7 @@ namespace detail {
 
 void set_thread_name( const std::string& name )
 {
-#if defined(LIBQ_ON_BSD)
+#if defined(LIBQ_ON_BSD) || defined(LIBQ_ON_ANDROID)
 
 	threadname_ = name;
 
@@ -137,7 +137,7 @@ void set_thread_name( const std::string& name )
 
 std::string get_thread_name( )
 {
-#if defined(LIBQ_ON_BSD)
+#if defined(LIBQ_ON_BSD) || defined(LIBQ_ON_ANDROID)
 
 	return threadname_;
 


### PR DESCRIPTION
 - Android standard library does not have execinfo.h, thus a empty stacktrace is returned for Android.

 - Android's pthread library does not allow setting and/or getting thread names, use a thread_local workaround on those situations.

 - setenv is also not available on Android standard library, so conditionally disable it when compiling against Android platforms.