### PR TITLE
Fixed ambiguous call to make_unique()

### DIFF
--- a/libs/q/include/q/scope.hpp
+++ b/libs/q/include/q/scope.hpp
@@ -79,7 +79,7 @@ make_scope( T&& t )
 {
 	typedef typename std::decay< T >::type type;
 
-	return scope( make_unique< detail::deleter< type > >( std::move( t ) ) );
+	return scope( q::make_unique< detail::deleter< type > >( std::move( t ) ) );
 }
 
 template< typename T >
@@ -93,7 +93,7 @@ make_scope( T&& t )
 {
 	typedef typename std::decay< T >::type type;
 
-	return scope( make_unique< detail::deleter< type > >( type( t ) ) );
+	return scope( q::make_unique< detail::deleter< type > >( type( t ) ) );
 }
 
 class scoped_function


### PR DESCRIPTION
Code using `q::make_scope()` fails to compile when a C++14 compiler is used. Tested using clang under macOS:
```
Apple LLVM version 9.0.0 (clang-900.0.37)
Target: x86_64-apple-darwin16.7.0
```

This PR resolves the ambiguity between `q::make_unique()` and `std::make_unique()` and solves this issue.