### PR TITLE
C++17 support for fn_match

### DIFF
--- a/libs/q/include/q/functional.hpp
+++ b/libs/q/include/q/functional.hpp
@@ -153,6 +153,53 @@ struct fn_match< R( C::* )( A... ) const >
 template< typename Fn >
 fn_match< Fn > fn_type( Fn&& );
 
+#if (defined(_MSVC_LANG) && _MSVC_LANG > 201402L) || (!defined(_MSVC_LANG) && __cplusplus > 201402L)
+
+template< typename R, typename... A >
+struct fn_match< R(&)(A...) noexcept>
+	: public fn_match< R(A...) >
+{ };
+
+template< typename R, typename... A >
+struct fn_match< R(*)(A...) noexcept>
+	: public fn_match< R(A...) >
+{ };
+
+template< typename R, typename... A >
+struct fn_match< R(A...) noexcept>
+	: public valid_t
+{
+	typedef R result_type;
+	typedef arguments< A... > argument_types;
+	typedef R(signature)(A...);
+	typedef R(*signature_ptr)(A...);
+	typedef void memberclass_type;
+	typedef void member_signature_ptr;
+	typedef std::false_type is_const;
+};
+
+template< typename R, typename C, typename... A >
+struct fn_match< R(C::*)(A...) noexcept>
+	: public fn_match< R(C::*)(A...) const >
+{
+	typedef std::false_type is_const;
+};
+
+template< typename R, typename C, typename... A >
+struct fn_match< R(C::*)(A...) const noexcept >
+	: public valid_t
+{
+	typedef R result_type;
+	typedef arguments< A... > argument_types;
+	typedef R(signature)(A...);
+	typedef R(*signature_ptr)(A...);
+	typedef C memberclass_type;
+	typedef R(C::*member_signature_ptr)(A...);
+	typedef std::true_type is_const;
+};
+
+#endif
+
 template< typename Fn, typename Enabled = void >
 struct has_call_operator
 : public std::false_type

--- a/libs/q/include/q/promise/promise.hpp
+++ b/libs/q/include/q/promise/promise.hpp
@@ -661,7 +661,8 @@ public:
 	typename std::enable_if<
 		std::is_void< _V >::value
 		and
-		argument_types::empty::value,
+		generic_promise< Shared, Args... >
+			::argument_types::empty::value,
 		promise< U... >
 	>::type
 	forward( U&&... values );


### PR DESCRIPTION
Adds `noexcept` specializations to `fn_match` to account for the exception specification becoming part of the type signature in c++17. The define allows the library to compile as-is when c++17 isn't supported.

Tested w/ MSVC 2017 and g++ 7.3.0

Fixes #17.